### PR TITLE
Add Python wrapper for glp_term_hook()

### DIFF
--- a/glpk.i
+++ b/glpk.i
@@ -17,6 +17,41 @@
 %{
 #define SWIG_FILE_WITH_INIT
 #include "./glpk.h"
+
+int wrap_glp_term_hook_cb(void *info, const char *s)
+{
+  PyObject *callback = (PyObject *)info;
+  PyObject *args = Py_BuildValue("(s)", s);
+  if (args == NULL) {
+    PyErr_Print();
+    goto out;
+  }
+
+  PyObject *r = PyObject_Call(callback, args, NULL);
+  if (r == NULL) {
+    PyErr_Print();
+    goto out;
+  }
+
+out:
+  Py_XDECREF(r);
+  Py_XDECREF(args);
+  return 1;
+}
+%}
+
+%rename(glp_term_hook) wrap_glp_term_hook;
+%inline %{
+PyObject *wrap_glp_term_hook(PyObject *callback)
+{
+  if (callback == Py_None) {
+    glp_term_hook(NULL, NULL);
+  } else {
+    glp_term_hook(wrap_glp_term_hook_cb, callback);
+  }
+
+  Py_RETURN_NONE;
+}
 %}
 
 %include "carrays.i"


### PR DESCRIPTION
This adds a wrapper for `glp_term_hook()` that takes a single Python callable. This allows any function defined in Python to be used as the callback for the terminal output hook. The unwrapped `glp_term_hook()` is still available by calling the function with two arguments.

For example to use the Python `logging` module for the output:

``` python
import logging
from swiglpk import *

logger = logging.getLogger(__name__)

def term_hook(s):
    logger.info(s)

glp_term_hook(term_hook)
# ...
glp_simplex(lp, None)
```