### PR TITLE
Appveyor fixes

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,7 +30,7 @@ init:
 
 install:
   - "powershell appveyor\\install.ps1"
-  - choco -y install swig
+  - cinst swig
 
   # Prepend newly installed Python to the PATH of this build (this cannot be
   # done from inside the powershell script as it would require to restart

--- a/setup.py
+++ b/setup.py
@@ -43,17 +43,6 @@ def copy_glpk_header():
         raise Exception('Could not find glpk.h! Maybe glpk or glpsol is not installed.')
 
 
-class CustomBuild(build):
-    def run(self):
-        self.run_command('build_ext')
-        build.run(self)
-
-
-class CustomInstall(install):
-    def run(self):
-        self.run_command('build_ext')
-        self.do_egg_install()
-
 # Copy and process glpk.h into current directory
 copy_glpk_header()
 
@@ -86,7 +75,6 @@ setup(
         'License :: OSI Approved :: Apache Software License',
     ],
     py_modules=['swiglpk'],
-    cmdclass={'build': CustomBuild, 'install': CustomInstall},
     ext_modules=[Extension("_swiglpk", sources=["glpk.i"], libraries=['glpk'])],
     include_package_data = True
 )


### PR DESCRIPTION
Hey, thanks for making this library. I noticed your work on getting AppVeyor to build windows wheels but it seems to be failing. I had to remove the customized build in `setup.py` to get it working. I'm not sure why the `CustomBuild` and `CustomInstall` were added in the first place but they did not seem to be necessary for me. Is there a reason to keep those around?