### PR TITLE
Suggestion for some helpers to avoid common bottlenecks

### DIFF
--- a/swiglpk/glpk.i
+++ b/swiglpk/glpk.i
@@ -61,11 +61,11 @@ PyObject *wrap_glp_term_hook(PyObject *callback)
 }
 %}
 
+%include glpk_clean.h
+
 %include "carrays.i"
 %array_class(int, intArray);
 %array_class(double, doubleArray);
-
-%include glpk_clean.h
 
 %inline %{
 PyObject* get_col_primals(glp_prob *P) {
@@ -116,7 +116,7 @@ PyObject* get_row_duals(glp_prob *P) {
     return list;
 }
 
-int* as_intArray(PyObject *list) {
+intArray* as_intArray(PyObject *list) {
     /* Check if is a list */
     if (PyList_Check(list)) {
         int size = PyList_Size(list);
@@ -131,13 +131,13 @@ int* as_intArray(PyObject *list) {
                return NULL;
             }
         }
-        return int_arr;
+        return (intArray*)int_arr;
     }
     PyErr_SetString(PyExc_TypeError, "not a list");
     return NULL;
 }
 
-double* as_doubleArray(PyObject *list) {
+doubleArray* as_doubleArray(PyObject *list) {
     /* Check if is a list */
     if (PyList_Check(list)) {
         int size = PyList_Size(list);
@@ -152,7 +152,7 @@ double* as_doubleArray(PyObject *list) {
                return NULL;
             }
         }
-        return double_arr;
+        return (doubleArray*)double_arr;
     }
     PyErr_SetString(PyExc_TypeError, "not a list");
     return NULL;

--- a/swiglpk/glpk.i
+++ b/swiglpk/glpk.i
@@ -72,7 +72,8 @@ PyObject* get_col_primals(glp_prob *P) {
     int n = glp_get_num_cols(P);
     PyObject* list = PyList_New(n);
     double prim = 0.0;
-    for(int i=1; i<=n; i++){
+    int i=0;
+    for(i=1; i<=n; i++){
         prim = glp_get_col_prim(P, i);
         PyList_SetItem(list, i-1, PyFloat_FromDouble(prim));
     }
@@ -83,10 +84,11 @@ PyObject* get_col_primals(glp_prob *P) {
 PyObject* get_col_duals(glp_prob *P) {
     int n = glp_get_num_cols(P);
     PyObject* list = PyList_New(n);
-    double prim = 0.0;
-    for(int i=1; i<=n; i++){
-        prim = glp_get_col_dual(P, i);
-        PyList_SetItem(list, i-1, PyFloat_FromDouble(prim));
+    double dual = 0.0;
+    int i=0;
+    for(i=1; i<=n; i++){
+        dual = glp_get_col_dual(P, i);
+        PyList_SetItem(list, i-1, PyFloat_FromDouble(dual));
     }
 
     return list;
@@ -96,7 +98,8 @@ PyObject* get_row_primals(glp_prob *P) {
     int n = glp_get_num_rows(P);
     PyObject* list = PyList_New(n);
     double prim = 0.0;
-    for(int i=1; i<=n; i++){
+    int i=0;
+    for(i=1; i<=n; i++){
         prim = glp_get_row_prim(P, i);
         PyList_SetItem(list, i-1, PyFloat_FromDouble(prim));
     }
@@ -107,10 +110,11 @@ PyObject* get_row_primals(glp_prob *P) {
 PyObject* get_row_duals(glp_prob *P) {
     int n = glp_get_num_rows(P);
     PyObject* list = PyList_New(n);
-    double prim = 0.0;
-    for(int i=1; i<=n; i++){
-        prim = glp_get_row_dual(P, i);
-        PyList_SetItem(list, i-1, PyFloat_FromDouble(prim));
+    double dual = 0.0;
+    int i=0;
+    for(i=1; i<=n; i++){
+        dual = glp_get_row_dual(P, i);
+        PyList_SetItem(list, i-1, PyFloat_FromDouble(dual));
     }
 
     return list;
@@ -121,7 +125,8 @@ intArray* as_intArray(PyObject *list) {
     if (PyList_Check(list)) {
         int size = PyList_Size(list);
         int *int_arr = (int *) malloc((size+1) * sizeof(int));
-        for (int i = 0; i < size; i++) {
+        int i=0;
+        for (i=0; i<size; i++) {
             PyObject *o = PyList_GetItem(list, i);
             if (PyInt_Check(o))
                int_arr[i+1] = PyInt_AsLong(o);
@@ -141,8 +146,9 @@ doubleArray* as_doubleArray(PyObject *list) {
     /* Check if is a list */
     if (PyList_Check(list)) {
         int size = PyList_Size(list);
-        int *double_arr = (int *) malloc((size+1) * sizeof(double));
-        for (int i = 0; i < size; i++) {
+        double *double_arr = (double *) malloc((size+1) * sizeof(double));
+        int i=0;
+        for (i=0; i<size; i++) {
             PyObject *o = PyList_GetItem(list, i);
             if (PyFloat_Check(o))
                double_arr[i+1] = PyFloat_AsDouble(o);

--- a/swiglpk/glpk.i
+++ b/swiglpk/glpk.i
@@ -67,4 +67,96 @@ PyObject *wrap_glp_term_hook(PyObject *callback)
 
 %include glpk_clean.h
 
+%inline %{
+PyObject* get_col_primals(glp_prob *P) {
+    int n = glp_get_num_cols(P);
+    PyObject* list = PyList_New(n);
+    double prim = 0.0;
+    for(int i=1; i<=n; i++){
+        prim = glp_get_col_prim(P, i);
+        PyList_SetItem(list, i-1, PyFloat_FromDouble(prim));
+    }
+
+    return list;
+}
+
+PyObject* get_col_duals(glp_prob *P) {
+    int n = glp_get_num_cols(P);
+    PyObject* list = PyList_New(n);
+    double prim = 0.0;
+    for(int i=1; i<=n; i++){
+        prim = glp_get_col_dual(P, i);
+        PyList_SetItem(list, i-1, PyFloat_FromDouble(prim));
+    }
+
+    return list;
+}
+
+PyObject* get_row_primals(glp_prob *P) {
+    int n = glp_get_num_rows(P);
+    PyObject* list = PyList_New(n);
+    double prim = 0.0;
+    for(int i=1; i<=n; i++){
+        prim = glp_get_row_prim(P, i);
+        PyList_SetItem(list, i-1, PyFloat_FromDouble(prim));
+    }
+
+    return list;
+}
+
+PyObject* get_row_duals(glp_prob *P) {
+    int n = glp_get_num_rows(P);
+    PyObject* list = PyList_New(n);
+    double prim = 0.0;
+    for(int i=1; i<=n; i++){
+        prim = glp_get_row_dual(P, i);
+        PyList_SetItem(list, i-1, PyFloat_FromDouble(prim));
+    }
+
+    return list;
+}
+
+int* as_intArray(PyObject *list) {
+    /* Check if is a list */
+    if (PyList_Check(list)) {
+        int size = PyList_Size(list);
+        int *int_arr = (int *) malloc((size+1) * sizeof(int));
+        for (int i = 0; i < size; i++) {
+            PyObject *o = PyList_GetItem(list, i);
+            if (PyInt_Check(o))
+               int_arr[i+1] = PyInt_AsLong(o);
+            else {
+               PyErr_SetString(PyExc_TypeError, "list must contain integers");
+               free(int_arr);
+               return NULL;
+            }
+        }
+        return int_arr;
+    }
+    PyErr_SetString(PyExc_TypeError, "not a list");
+    return NULL;
+}
+
+double* as_doubleArray(PyObject *list) {
+    /* Check if is a list */
+    if (PyList_Check(list)) {
+        int size = PyList_Size(list);
+        int *double_arr = (int *) malloc((size+1) * sizeof(double));
+        for (int i = 0; i < size; i++) {
+            PyObject *o = PyList_GetItem(list, i);
+            if (PyFloat_Check(o))
+               double_arr[i+1] = PyFloat_AsDouble(o);
+            else {
+               PyErr_SetString(PyExc_TypeError, "list must contain floats");
+               free(double_arr);
+               return NULL;
+            }
+        }
+        return double_arr;
+    }
+    PyErr_SetString(PyExc_TypeError, "not a list");
+    return NULL;
+}
+%}
+
 %module swiglpk


### PR DESCRIPTION
This is a proposal to add helpers to get all row/column primal/duals in one go from the C level as well as helper functions that convert Python lists to the required int/doubleArray types.

Easier to understand with some examples (sorry for using cobrapy here, just makes it easier to construct a test problem):

```Python
In [1]: from cobra.test import create_test_model

In [2]: mod = create_test_model("textbook")

In [3]: mod.optimize()
Out[3]: <Solution 0.874 at 0x7efd06db6fd0>

In [4]: %time mod.solver.optimize()
CPU times: user 0 ns, sys: 0 ns, total: 0 ns
Wall time: 230 µs
Out[4]: 'optimal'

In [5]: import swiglpk

In [6]: %time x = mod.solver.primal_values
CPU times: user 0 ns, sys: 0 ns, total: 0 ns
Wall time: 1.24 ms

In [7]: %time y = swiglpk.get_col_primals(mod.solver.problem)
CPU times: user 0 ns, sys: 0 ns, total: 0 ns
Wall time: 41.2 µs

In [8]: sum(abs(x-y) for x, y in zip(x.values(), y))
Out[8]: 0.0

In [9]: def to_ia(x):
   ...:     ia = swiglpk.intArray(len(x))
   ...:     for i in range(len(x)): ia[i] = x[i]
   ...:     

In [10]: li = list(range(10000))

In [11]: %time ia = to_ia(li)
CPU times: user 16 ms, sys: 0 ns, total: 16 ms
Wall time: 17.4 ms

In [12]: %time ia = swiglpk.as_intArray(li)
CPU times: user 4 ms, sys: 0 ns, total: 4 ms
Wall time: 314 µs

```

Basically getting all primals/duals at onces is about 100x faster than iterating them in Python, and more importantly, is also faster than resolving the model.

Constructing large input arrays from Python lists directly in C is also much faster than doing it in Python.