### PR TITLE
Get correct primal for MIP problems [needs review]

### DIFF
--- a/swiglpk/glpk.i
+++ b/swiglpk/glpk.i
@@ -74,13 +74,17 @@ PyObject* get_col_primals(glp_prob *P) {
     double prim = 0.0;
     int n_int = glp_get_num_int(P);
     int i = 0;
-    for(i=1; i<=n; i++){
-        if (n_int == 0) {
+
+    if (n_int == 0) {
+        for(i=1; i<=n; i++) {
             prim = glp_get_col_prim(P, i);
-        } else {
-            prim = glp_mip_col_val(P, i);
+            PyList_SetItem(list, i-1, PyFloat_FromDouble(prim));
         }
-        PyList_SetItem(list, i-1, PyFloat_FromDouble(prim));
+    } else {
+        for(i=1; i<=n; i++) {
+            prim = glp_mip_col_val(P, i);
+            PyList_SetItem(list, i-1, PyFloat_FromDouble(prim));
+        }
     }
 
     return list;
@@ -91,7 +95,7 @@ PyObject* get_col_duals(glp_prob *P) {
     PyObject* list = PyList_New(n);
     double dual = 0.0;
     int i = 0;
-    for(i=1; i<=n; i++){
+    for(i=1; i<=n; i++) {
         dual = glp_get_col_dual(P, i);
         PyList_SetItem(list, i-1, PyFloat_FromDouble(dual));
     }
@@ -103,10 +107,19 @@ PyObject* get_row_primals(glp_prob *P) {
     int n = glp_get_num_rows(P);
     PyObject* list = PyList_New(n);
     double prim = 0.0;
+    int n_int = glp_get_num_int(P);
     int i = 0;
-    for(i=1; i<=n; i++){
-        prim = glp_get_row_prim(P, i);
-        PyList_SetItem(list, i-1, PyFloat_FromDouble(prim));
+
+    if (n_int == 0) {
+        for(i=1; i<=n; i++) {
+            prim = glp_get_row_prim(P, i);
+            PyList_SetItem(list, i-1, PyFloat_FromDouble(prim));
+        }
+    } else {
+        for(i=1; i<=n; i++) {
+            prim = glp_mip_row_val(P, i);
+            PyList_SetItem(list, i-1, PyFloat_FromDouble(prim));
+        }
     }
 
     return list;

--- a/swiglpk/glpk.i
+++ b/swiglpk/glpk.i
@@ -72,9 +72,14 @@ PyObject* get_col_primals(glp_prob *P) {
     int n = glp_get_num_cols(P);
     PyObject* list = PyList_New(n);
     double prim = 0.0;
-    int i=0;
+    int n_int = glp_get_num_int(P);
+    int i = 0;
     for(i=1; i<=n; i++){
-        prim = glp_get_col_prim(P, i);
+        if (n_int == 0) {
+            prim = glp_get_col_prim(P, i);
+        } else {
+            prim = glp_mip_col_val(P, i);
+        }
         PyList_SetItem(list, i-1, PyFloat_FromDouble(prim));
     }
 
@@ -85,7 +90,7 @@ PyObject* get_col_duals(glp_prob *P) {
     int n = glp_get_num_cols(P);
     PyObject* list = PyList_New(n);
     double dual = 0.0;
-    int i=0;
+    int i = 0;
     for(i=1; i<=n; i++){
         dual = glp_get_col_dual(P, i);
         PyList_SetItem(list, i-1, PyFloat_FromDouble(dual));
@@ -98,7 +103,7 @@ PyObject* get_row_primals(glp_prob *P) {
     int n = glp_get_num_rows(P);
     PyObject* list = PyList_New(n);
     double prim = 0.0;
-    int i=0;
+    int i = 0;
     for(i=1; i<=n; i++){
         prim = glp_get_row_prim(P, i);
         PyList_SetItem(list, i-1, PyFloat_FromDouble(prim));
@@ -111,7 +116,7 @@ PyObject* get_row_duals(glp_prob *P) {
     int n = glp_get_num_rows(P);
     PyObject* list = PyList_New(n);
     double dual = 0.0;
-    int i=0;
+    int i = 0;
     for(i=1; i<=n; i++){
         dual = glp_get_row_dual(P, i);
         PyList_SetItem(list, i-1, PyFloat_FromDouble(dual));
@@ -125,7 +130,7 @@ intArray* as_intArray(PyObject *list) {
     if (PyList_Check(list)) {
         int size = PyList_Size(list);
         int *int_arr = (int *) malloc((size+1) * sizeof(int));
-        int i=0;
+        int i = 0;
         for (i=0; i<size; i++) {
             PyObject *o = PyList_GetItem(list, i);
             if (PyInt_Check(o))
@@ -147,7 +152,7 @@ doubleArray* as_doubleArray(PyObject *list) {
     if (PyList_Check(list)) {
         int size = PyList_Size(list);
         double *double_arr = (double *) malloc((size+1) * sizeof(double));
-        int i=0;
+        int i = 0;
         for (i=0; i<size; i++) {
             PyObject *o = PyList_GetItem(list, i);
             if (PyFloat_Check(o))


### PR DESCRIPTION
Pinging @KristianJensen for review. 

Tried to do it like optlang but realized that optlang has a bug when getting primals from MIP problems. If the problem is a MIP problem all primal values have to be requested with `glp_mip_col_val` including continuous columns. Otherwise you will get incorrect primals for columns that are continuous but constrained by integer variables since it requests them from the "normal" LP solution that ignores integer variables. 

For now `get_col_primals` will deem a problem a MIP problem if there is at least one binary or integer variable and get all primals from the MIP solution in that case. 