### PR TITLE
Add newer swig

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,6 +11,7 @@ environment:
       # /E:ON and /V:ON options are not enabled in the batch script intepreter
       # See: http://stackoverflow.com/a/13751649/163740
       CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\appveyor\\run_with_env.cmd"
+      SWIG_VERSION: "3.0.12"
 
   matrix:
 
@@ -110,7 +111,10 @@ install:
   - "pip install --disable-pip-version-check --user --upgrade pip"
 
   - "powershell appveyor\\install.ps1"
-  - choco install -y swig
+
+  # Use newer version of swig
+  - "7z x appveyor\\swigwin-%%SWIG_VERSION.zip"
+  - "SET PATH=swigwin-%SWIG_VERSION%;%PATH%"
 
   - "%PYTHON%/python -m pip install pip setuptools>=34.0 nose twine wheel --upgrade"
   - "%CMD_IN_ENV% %PYTHON%/python appveyor/build_glpk.py"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -113,7 +113,7 @@ install:
   - "powershell appveyor\\install.ps1"
 
   # Use newer version of swig
-  - "7z x appveyor\\swigwin-%%SWIG_VERSION.zip"
+  - "7z x appveyor\\swigwin-%SWIG_VERSION%.zip"
   - "SET PATH=swigwin-%SWIG_VERSION%;%PATH%"
 
   - "%PYTHON%/python -m pip install pip setuptools>=34.0 nose twine wheel --upgrade"


### PR DESCRIPTION
SWIG < 3.0.8 does not build Python 3.5/3.6 wrappers correctly. This PR uses swig 3.0.12. Downloading it dynamically is hard due to sourceforge so for now I just put it in the appveyor folder.

In the long run you might want to update the appveyor config since it is pretty outdated, e.g.:
- reinstalls all Python versions even there are newer versions already preinstalled
- uses old versions for instance 2.7.10 instead of 2.7.13 