### PR TITLE
Fix travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
-python: 3.5
-sudo: required
-dist: trusty
+python: 3.8
+os: linux
+dist: focal
 services: docker
 env:
   global:
@@ -18,9 +18,7 @@ branches:
   - devel
   - /^[0-9]+\.[0-9]+\.[0-9]+[.0-9ab]*$/
 
-matrix:
-  exclude:
-    - python: 3.5
+jobs:
   include:
     - os: linux
       env:
@@ -117,15 +115,14 @@ script:
 
 deploy:
   - provider: script
-    skip_cleanup: true
+    cleanup: false
     script: scripts/deploy.sh
     on:
       branch: master
       tags: true
   - provider: script
-    skip_cleanup: true
+    cleanup: false
     script: scripts/release.sh
     on:
       branch: master
       condition: '$TRAVIS_EVENT_TYPE = cron && $MB_PYTHON_VERSION = 3.7 && $TRAVIS_OS_NAME = osx'
-


### PR DESCRIPTION
### Description
Travis has not been building any workflow for a long time. The reason is that the job matrix is excluding the python version of the distribution that is running the workflow. This happens at the distribution level (not at the multibuild docker level), resulting in an empty job matrix.

This can be checked by pasting the current `.travis.yml` at https://config.travis-ci.com/explore
```
xclip -sel clipboard <(curl https://raw.githubusercontent.com/biosustain/swiglpk/ec985c15ae507139de70b943c56f1042acd79a8a/.travis.yml)
```

#### Implementation
* Removed `exclude` python directive. 
* Updated distribution to focal fossa.
* Updated python version to 3.8.
* Some clean-up of deprecated syntax.