### PR TITLE
Respect --skip-build flag

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,8 @@ try:
 
     class CustomBdistWheel(bdist_wheel):
         def run(self):
-            self.run_command('build_ext')
+            if not self.skip_build:
+                self.run_command('build_ext')
             bdist_wheel.run(self)
 
     custom_cmd_class['bdist_wheel'] = CustomBdistWheel


### PR DESCRIPTION
`python setup.py bdist-wheel --skip-build` is supposed to skip building the package. We need this in Pyodide https://github.com/pyodide/pyodide/pull/2027 because of the way our cross compilation works. I'm actually not sure why this isn't causing trouble for us on our main branch,