### PR TITLE
Enable Linux ARM builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,7 +59,7 @@ jobs:
           CIBW_BEFORE_BUILD_WINDOWS: rm -rf glpk_build && python scripts/build_glpk.py
           CIBW_ARCHS_MACOS: "arm64 x86_64"
           CIBW_ARCHS_LINUX: "auto aarch64"
-          CIBW_SKIP: pp*-win* *-musllinux* cp36-*_aarch64 cp37-*_aarch64
+          CIBW_SKIP: pp*-win* *-musllinux* cp36-*_aarch64 cp37-*_aarch64 pp*-*_aarch64
           # install before tests
           CIBW_TEST_COMMAND: cp {project}/test_swiglpk.py . && python test_swiglpk.py
           CIBW_TEST_SKIP: "*_arm64"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,8 +58,8 @@ jobs:
           CIBW_BEFORE_BUILD_MACOS: source {project}/config.sh && IS_OSX=true pre_build
           CIBW_BEFORE_BUILD_WINDOWS: rm -rf glpk_build && python scripts/build_glpk.py
           CIBW_ARCHS_MACOS: "arm64 x86_64"
-          CIBW_ARCHS_LINUX: "auto"
-          CIBW_SKIP: pp*-win* *-musllinux*
+          CIBW_ARCHS_LINUX: "auto aarch64"
+          CIBW_SKIP: pp*-win* *-musllinux* cp36-*_aarch64 cp37-*_aarch64
           # install before tests
           CIBW_TEST_COMMAND: cp {project}/test_swiglpk.py . && python test_swiglpk.py
           CIBW_TEST_SKIP: "*_arm64"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -84,6 +84,7 @@ jobs:
     - name: Get versions
       id: version
       run: |
+        python -m pip install requests
         echo "::set-output name=glpk_version::$(python scripts/find_newest_glpk_release.py)"
         echo "::set-output name=swigplk_version::$(python scripts/find_swiglpk_version.py)"
     - name: Install dependencies


### PR DESCRIPTION
Only selected the 3 most recent python versions to keep the build time down.